### PR TITLE
fixed a bug in the flamechart. latest layer was not shown at all

### DIFF
--- a/js/c3-layers.coffee
+++ b/js/c3-layers.coffee
@@ -1154,7 +1154,9 @@ class c3.Plot.Layer.Swimlane.Flamechart extends c3.Plot.Layer.Swimlane.Segment
             while stack.length and frame.x >= (_frame=stack[stack.length-1]).x + _frame.dx
                 stack.length--
             stack.push frame
-            max_depth = Math.max max_depth, stack.length-1
+            max_depth = Math.max max_depth, stack.length
+	    # here depths is rather the layer number starting from 0 than the depth
+	    # itself, so we must not reduce here 1
             @depths[@key datum] = stack.length - 1
         
         # Set the vertical domain and resize chart based on maximum flamechart depth

--- a/js/c3-layers.js
+++ b/js/c3-layers.js
@@ -1633,7 +1633,7 @@
           stack.length--;
         }
         stack.push(frame);
-        max_depth = Math.max(max_depth, stack.length - 1);
+        max_depth = Math.max(max_depth, stack.length);
         this.depths[this.key(datum)] = stack.length - 1;
       }
       this.v.domain([0, max_depth]);


### PR DESCRIPTION
You can verify this by looking for the chains read_tsc->native_read_tsc from examples/flamechart_sunburst_example.js / flamechart_sunburst_example.html
In the middle of the flame chart there is the deepest callstack and without this fix it is finished by read_tsc wile all read_tsc call native_read_tsc in the trace.

I didn't take a look how to the this.depths usage, but it seems it is not th deep, but rather layer. the same fix will lead to the moving of all layers to one layer below. So, I decided to leave the second line as is.